### PR TITLE
Add pytest test for index.html image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 Privstaxi
+
+## Tests
+
+Install the test dependencies and run pytest:
+
+```bash
+pip install pytest
+pytest
+```

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
     <section id="accueil">
         <h2>Bienvenue chez PRIVS TAXI</h2>
         <div class="car-container">
-            <img src="ChatGPT Image 2 avr. 2025, 14_09_45" alt="SITE EN MANTENANCE...">
+            <img src="ChatGPT Image 2 avr. 2025, 14_09_45.png" alt="SITE EN MAINTENANCE...">
         </div>
     </section>
     

--- a/tests/test_index_html.py
+++ b/tests/test_index_html.py
@@ -1,0 +1,25 @@
+import os
+import re
+
+
+def parse_img_tag(html):
+    match = re.search(r"<img[^>]*>", html, re.IGNORECASE)
+    assert match, "No img tag found"
+    tag = match.group(0)
+    src_match = re.search(r'src="([^\"]+)"', tag)
+    assert src_match, "src attribute missing"
+    alt_match = re.search(r'alt="([^\"]+)"', tag)
+    assert alt_match, "alt attribute missing"
+    return src_match.group(1), alt_match.group(1)
+
+
+def test_image_exists_and_alt_text():
+    index_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "index.html")
+    with open(index_path, encoding="utf-8") as f:
+        html = f.read()
+    src, alt = parse_img_tag(html)
+    # image path relative to repository root
+    image_path = os.path.join(os.path.dirname(index_path), src)
+    assert os.path.exists(image_path), f"Image {src} does not exist"
+    assert alt == "SITE EN MAINTENANCE..."
+


### PR DESCRIPTION
## Summary
- add a pytest test ensuring index.html image exists and alt text is correct
- fix img tag in index.html
- document how to run tests with pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b9b67e1d4832ca2f5a0046e1d7db7