### PR TITLE
Add Leaflet map and route calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PRIVS TAXI - Luxe & Prestige</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap');
         body { 
@@ -87,6 +88,9 @@
             border-radius: 15px; 
             box-shadow: 0 10px 30px rgba(255, 255, 255, 0.3);
         }
+        #map { height: 400px; margin-top: 20px; }
+        .form-group { margin-bottom: 10px; }
+        #info { margin-top: 15px; font-size: 20px; }
     </style>
 </head>
 <body>
@@ -110,9 +114,19 @@
         <p>Transferts aéroport premium, mise à disposition avec chauffeur privé, trajets sur mesure dans des véhicules d'exception...</p>
     </section>
     
-    <section id="reservation">
+<section id="reservation">
         <h2>Réservez votre course d'exception</h2>
-        <button class="button">Réserver maintenant</button>
+        <form id="route-form">
+            <div class="form-group">
+                <input type="text" id="pickup" placeholder="Adresse de prise en charge" required>
+            </div>
+            <div class="form-group">
+                <input type="text" id="destination" placeholder="Adresse de destination" required>
+            </div>
+            <button type="submit" class="button">Calculer la course</button>
+        </form>
+        <div id="info">Distance : <span id="distance">-</span> | Prix estimé : <span id="price">-</span></div>
+        <div id="map"></div>
     </section>
     
     <section id="contact">
@@ -124,5 +138,7 @@
     <footer>
         &copy; 2025 PRIVS TAXI - Tous droits réservés | Luxembourg
     </footer>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,59 @@
+const map = L.map("map").setView([49.6116, 6.1319], 13);
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: "&copy; OpenStreetMap contributors"
+}).addTo(map);
+
+let startMarker, endMarker, routeLine;
+
+async function geocode(q) {
+    const resp = await fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(q)}`);
+    if (!resp.ok) throw new Error("Erreur de géocodage");
+    const data = await resp.json();
+    if (!data[0]) throw new Error("Adresse introuvable");
+    return { lat: parseFloat(data[0].lat), lon: parseFloat(data[0].lon) };
+}
+
+async function calculateRoute(start, dest) {
+    const url = `https://router.project-osrm.org/route/v1/driving/${start.lon},${start.lat};${dest.lon},${dest.lat}?overview=full&geometries=geojson`;
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error("Erreur de calcul d'itinéraire");
+    const json = await resp.json();
+    return json.routes[0];
+}
+
+function displayRoute(route, start, dest) {
+    if (routeLine) map.removeLayer(routeLine);
+    if (startMarker) map.removeLayer(startMarker);
+    if (endMarker) map.removeLayer(endMarker);
+    routeLine = L.geoJSON(route.geometry).addTo(map);
+    startMarker = L.marker([start.lat, start.lon]).addTo(map);
+    endMarker = L.marker([dest.lat, dest.lon]).addTo(map);
+    map.fitBounds(routeLine.getBounds());
+    const distanceKm = route.distance / 1000;
+    document.getElementById("distance").textContent = distanceKm.toFixed(2) + " km";
+    document.getElementById("price").textContent = (distanceKm * 2).toFixed(2) + " €";
+}
+
+document.getElementById("route-form").addEventListener("submit", async e => {
+    e.preventDefault();
+    const startText = document.getElementById("pickup").value;
+    const endText = document.getElementById("destination").value;
+    try {
+        const [start, dest] = await Promise.all([geocode(startText), geocode(endText)]);
+        const route = await calculateRoute(start, dest);
+        displayRoute(route, start, dest);
+    } catch (err) {
+        alert(err.message);
+    }
+});
+
+if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(pos => {
+        const { latitude, longitude } = pos.coords;
+        map.setView([latitude, longitude], 13);
+    }, () => {
+        console.warn("Impossible de récupérer la position de l'utilisateur");
+    });
+} else {
+    console.warn("La géolocalisation n'est pas supportée");
+}


### PR DESCRIPTION
## Summary
- embed Leaflet stylesheet
- style map and form areas
- add reservation form with geocoded route calculation
- include Leaflet JS and custom script
- implement script to geocode addresses, fetch OSRM route and show markers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c5c8fdfdc832c8d6bab9aaa72ecd8